### PR TITLE
hw-08

### DIFF
--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -27,8 +27,8 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        16,
-        16,
+        50,
+        50,
         0L,
         TimeUnit.MILLISECONDS,
         LinkedBlockingQueue(8_000),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,5 +26,5 @@ management.endpoints.web.exposure.include=info,health,prometheus,metrics
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=${PAYMENT_ACCOUNTS:acc-12,acc-20}
-payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}
+payment.accounts=${PAYMENT_ACCOUNTS:acc-9}
+payment.hostPort=localhost:1234

--- a/test-local-run.http
+++ b/test-local-run.http
@@ -5,9 +5,9 @@ Content-Type: application/json
 {
   "serviceName": "{{serviceName}}",
   "token": "{{token}}",
-  "ratePerSecond": 1,
-  "testCount": 100,
-  "processingTimeMillis": 80000
+  "ratePerSecond": 100,
+  "testCount": 5000,
+  "processingTimeMillis": 20000
 }
 
 ### Stop running test to save time and resources


### PR DESCRIPTION
В логах видим Payment accounts list: PaymentAccountProperties(serviceName=bloodyJavaBullet, accountName=acc-9, parallelRequests=50, rateLimitPerSec=120, price=30, averageProcessingTime=PT0.5S, enabled=true)

Смотрим на график:
<img width="1060" height="535" alt="image" src="https://github.com/user-attachments/assets/c03d54dc-fa22-4fd9-84cc-449c1f3bf754" />

Первые успевают обрабатываться, остальные явно долго ждут и фейлят тесты. Фиксированный пул потоков даст гарантию, что каждый запрос будет обрабатываться в текущий момент времени, из минусов - потоки могут простаивать, есть смысл оптимизировать (в джаве аналоги cashed pool, с динамическим изменением и самоуничтожением потоков каждые n, обычно 60 секунд). 

<img width="1085" height="547" alt="image" src="https://github.com/user-attachments/assets/a4e0298b-32cf-4d75-b772-f70e45d25cb2" />
