### PR TITLE
Hw 09

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ RUN mvn dependency:go-offline
 COPY src src
 RUN mvn package
 
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-alpine-3.22
 
 COPY --from=build /app/target/*.jar /high-load-course.jar
 
 CMD ["java", "-jar", "/high-load-course.jar"]
-

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <exclusions>
                 <exclusion>

--- a/src/main/kotlin/ru/quipy/common/utils/NonBlockingSlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/NonBlockingSlidingWindowRateLimiter.kt
@@ -1,0 +1,47 @@
+package ru.quipy.common.utils
+
+import kotlinx.coroutines.*
+import java.util.concurrent.atomic.AtomicLong
+import java.time.Duration
+import java.util.concurrent.ConcurrentLinkedDeque
+
+class NonBlockingSlidingWindowRateLimiter(
+    private val rate: Int,
+    private val window: Duration = Duration.ofSeconds(1)
+) {
+    private val counter = AtomicLong(0)
+    private val timestamps = ConcurrentLinkedDeque<Long>()
+
+    private fun cleanupExpired() {
+        val threshold = System.currentTimeMillis() - window.toMillis()
+        while (true) {
+            val head = timestamps.peekFirst() ?: break
+            if (head >= threshold) break
+            timestamps.pollFirst()
+            counter.decrementAndGet()
+        }
+    }
+
+    fun tryAcquire(): Boolean {
+        cleanupExpired()
+
+        while (true) {
+            val current = counter.get()
+            if (current >= rate) return false
+
+            if (counter.compareAndSet(current, current + 1)) {
+                timestamps.addLast(System.currentTimeMillis())
+                return true
+            }
+        }
+    }
+
+    suspend fun acquireSuspend(timeoutMs: Long): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (!tryAcquire()) {
+            if (System.currentTimeMillis() >= deadline) return false
+            delay(1)
+        }
+        return true
+    }
+}

--- a/src/main/kotlin/ru/quipy/common/utils/NonBlockingSlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/NonBlockingSlidingWindowRateLimiter.kt
@@ -4,44 +4,52 @@ import kotlinx.coroutines.*
 import java.util.concurrent.atomic.AtomicLong
 import java.time.Duration
 import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
 
 class NonBlockingSlidingWindowRateLimiter(
     private val rate: Int,
     private val window: Duration = Duration.ofSeconds(1)
 ) {
-    private val counter = AtomicLong(0)
-    private val timestamps = ConcurrentLinkedDeque<Long>()
+    private val timestamps = ConcurrentLinkedQueue<Long>()
+    private val currentCount = AtomicInteger(0)
 
-    private fun cleanupExpired() {
-        val threshold = System.currentTimeMillis() - window.toMillis()
-        while (true) {
-            val head = timestamps.peekFirst() ?: break
-            if (head >= threshold) break
-            timestamps.pollFirst()
-            counter.decrementAndGet()
+    suspend fun acquireSuspend(timeoutMillis: Long): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMillis
+
+        while (System.currentTimeMillis() < deadline) {
+            removeExpired()
+            if (currentCount.get() < rate) {
+                val now = System.currentTimeMillis()
+                if (tryAdd(now)) {
+                    return true
+                }
+            }
+            delay(10)
         }
+        return false
     }
 
-    fun tryAcquire(): Boolean {
-        cleanupExpired()
-
+    private fun removeExpired() {
+        val expiration = System.currentTimeMillis() - window.toMillis()
         while (true) {
-            val current = counter.get()
-            if (current >= rate) return false
-
-            if (counter.compareAndSet(current, current + 1)) {
-                timestamps.addLast(System.currentTimeMillis())
-                return true
+            val ts = timestamps.peek() ?: break
+            if (ts < expiration) {
+                timestamps.poll()
+                currentCount.decrementAndGet()
+            } else {
+                break
             }
         }
     }
 
-    suspend fun acquireSuspend(timeoutMs: Long): Boolean {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (!tryAcquire()) {
-            if (System.currentTimeMillis() >= deadline) return false
-            delay(1)
+    private fun tryAdd(now: Long): Boolean {
+        if (currentCount.incrementAndGet() <= rate) {
+            timestamps.add(now)
+            return true
+        } else {
+            currentCount.decrementAndGet()
+            return false
         }
-        return true
     }
 }

--- a/src/main/kotlin/ru/quipy/common/utils/NonBlockingSlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/NonBlockingSlidingWindowRateLimiter.kt
@@ -25,7 +25,7 @@ class NonBlockingSlidingWindowRateLimiter(
                     return true
                 }
             }
-            delay(10)
+            delay(1)
         }
         return false
     }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -44,9 +44,9 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val rateLimiter = NonBlockingSlidingWindowRateLimiter(
-        rate = rateLimitPerSec,
-    )
+    private val rateLimiter: NonBlockingSlidingWindowRateLimiter by lazy {
+        NonBlockingSlidingWindowRateLimiter(rate = rateLimitPerSec)
+    }
 
     private val paymentScope = CoroutineScope(
         Dispatchers.IO + SupervisorJob() + CoroutineName("payment-service-$accountName")
@@ -99,6 +99,9 @@ class PaymentExternalSystemAdapterImpl(
 
         while (!success && attempt++ < MAX_RETRY_ATTEMPTS) {
             try {
+                if (attempt > 1) {
+                    delay(50)
+                }
                 val timeUntilDeadline = deadline - now()
                 if (timeUntilDeadline <= 0) {
                     message = "Deadline exceeded"

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -2,30 +2,40 @@ package ru.quipy.payments.logic
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody
+import io.netty.channel.ChannelOption
+import io.netty.handler.timeout.ReadTimeoutHandler
+import io.netty.handler.timeout.WriteTimeoutHandler
+import kotlinx.coroutines.*
 import org.slf4j.LoggerFactory
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.reactive.function.client.awaitBody
+import org.springframework.web.reactive.function.client.awaitExchange
+import reactor.netty.http.client.HttpClient
+import reactor.netty.resources.ConnectionProvider
+import ru.quipy.common.utils.NonBlockingSlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
+import java.io.IOException
 import java.net.SocketTimeoutException
 import java.time.Duration
 import java.util.*
+import java.util.concurrent.TimeUnit
 
-
-// Advice: always treat time as a Duration
 class PaymentExternalSystemAdapterImpl(
     private val properties: PaymentAccountProperties,
     private val paymentESService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>,
     private val paymentProviderHostPort: String,
-    private val token: String,
+    private val token: String
 ) : PaymentExternalSystemAdapter {
 
     companion object {
         val logger = LoggerFactory.getLogger(PaymentExternalSystemAdapter::class.java)
-
-        val emptyBody = RequestBody.create(null, ByteArray(0))
         val mapper = ObjectMapper().registerKotlinModule()
+
+        val CONNECT_TIMEOUT: Duration = Duration.ofSeconds(1)
+        const val MAX_RETRY_ATTEMPTS = 3
     }
 
     private val serviceName = properties.serviceName
@@ -34,59 +44,102 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val client = OkHttpClient.Builder().build()
+    private val rateLimiter = NonBlockingSlidingWindowRateLimiter(
+        rate = rateLimitPerSec,
+    )
+
+    private val paymentScope = CoroutineScope(
+        Dispatchers.IO + SupervisorJob() + CoroutineName("payment-service-$accountName")
+    )
+
+    private val connectionProvider = ConnectionProvider.builder("payment-service-$accountName")
+        .maxConnections(parallelRequests)
+        .pendingAcquireMaxCount(-1)
+        .maxIdleTime(Duration.ofSeconds(30))
+        .build()
+
+    private val webClient: WebClient by lazy {
+        val timeoutMs = (requestAverageProcessingTime.toMillis() * 1.5).toLong()
+
+        val httpClient = HttpClient.create(connectionProvider)
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT.toMillis().toInt())
+            .responseTimeout(Duration.ofMillis(timeoutMs))
+            .doOnConnected { conn ->
+                conn.addHandlerLast(ReadTimeoutHandler(timeoutMs, TimeUnit.MILLISECONDS))
+                conn.addHandlerLast(WriteTimeoutHandler(CONNECT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS))
+            }
+
+        WebClient.builder()
+            .clientConnector(ReactorClientHttpConnector(httpClient))
+            .build()
+    }
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+        paymentScope.launch {
+            executePaymentSuspend(paymentId, amount, paymentStartedAt, deadline)
+        }
+    }
+
+    private suspend fun executePaymentSuspend(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         logger.warn("[$accountName] Submitting payment request for payment $paymentId")
 
         val transactionId = UUID.randomUUID()
 
-        // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
-        // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
-        paymentESService.update(paymentId) {
-            it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
+        withContext(Dispatchers.IO) {
+            paymentESService.update(paymentId) {
+                it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
+            }
         }
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
-        try {
-            val request = Request.Builder().run {
-                url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
-                post(emptyBody)
-            }.build()
+        var attempt = 0
+        var message: String? = null
+        var success = false
 
-            client.newCall(request).execute().use { response ->
-                val body = try {
-                    mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
-                } catch (e: Exception) {
-                    logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
-                    ExternalSysResponse(transactionId.toString(), paymentId.toString(),false, e.message)
+        while (!success && attempt++ < MAX_RETRY_ATTEMPTS) {
+            try {
+                val timeUntilDeadline = deadline - now()
+                if (timeUntilDeadline <= 0) {
+                    message = "Deadline exceeded"
+                    break
                 }
 
-                logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+                if (!rateLimiter.acquireSuspend(timeUntilDeadline)) {
+                    message = "Deadline exceeded"
+                    break
+                }
 
-                // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
-                // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
-                paymentESService.update(paymentId) {
-                    it.logProcessing(body.result, now(), transactionId, reason = body.message)
+                webClient.post()
+                    .uri("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
+                    .awaitExchange { response ->
+                        val statusCode = response.statusCode()
+                        if (statusCode.is2xxSuccessful) {
+                            val body = try {
+                                mapper.readValue(response.awaitBody<String>(), ExternalSysResponse::class.java)
+                            } catch (e: Exception) {
+                                logger.error("[$accountName] [ERROR] Failed to parse response for txId: $transactionId, payment: $paymentId", e)
+                                ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
+                            }
+
+                            logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+
+                            message = body.message
+                            success = body.result
+                        }
+                    }
+            } catch (e: Exception) {
+                if (!isRetryableException(e)) {
+                    logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
+                    message = e.message
+                    break
                 }
             }
-        } catch (e: Exception) {
-            when (e) {
-                is SocketTimeoutException -> {
-                    logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
-                    }
-                }
+        }
 
-                else -> {
-                    logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
-
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = e.message)
-                    }
-                }
+        withContext(Dispatchers.IO) {
+            paymentESService.update(paymentId) {
+                it.logProcessing(success, now(), transactionId, reason = message)
             }
         }
     }
@@ -96,7 +149,14 @@ class PaymentExternalSystemAdapterImpl(
     override fun isEnabled() = properties.enabled
 
     override fun name() = properties.accountName
+}
 
+fun isRetryableException(e: Exception): Boolean {
+    if (e is WebClientResponseException) {
+        return e.statusCode.value() == 429 || e.statusCode.is5xxServerError
+    }
+    return e is SocketTimeoutException ||
+            e is IOException || e.cause?.let { isRetryableException(it as? Exception ?: return@let false) } ?: false
 }
 
 public fun now() = System.currentTimeMillis()


### PR DESCRIPTION
![stats](https://github.com/user-attachments/assets/654b4102-c500-4834-83b7-7a40f26b8495)
![stats](https://github.com/user-attachments/assets/96a55f91-7dc1-44d7-9eb5-cc2c257f6aca)
![stats](https://github.com/user-attachments/assets/6287a080-b377-4cad-a34f-91e1bb27ed83)

В тесте rps = 1000, время ответа от сервера = 10сек. Это значит, что для максимальной производительности нам нужно 1000*10=10000 потоков, которые будут ждать ответа. Это как минимум плохо по памяти

Поэтому нужно выполнять неблокирующие запросы. То есть не ожидать получение ответа, а отправить запрос и освободить поток, а при получении ответа свободный поток его обработает.
Для этого меняем блокирующий OkHttpClient на неблокирующий WebClient
Также сделан неблокирующий rate limiter, чтобы при ожидании разрешения отправки запроса корутина. просто приостанавливалась, а не блокировала поток